### PR TITLE
Get query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ bq.job.query(prjId, 'select count(*) from publicdata:samples.wikipedia', functio
 });
 ```
 
+## Get Query Results
+
+Retrieve results from previous query.  Larger queries will timeout and respond before ther esults are collected.  Use this to retrieve the results.  Below is an example.
+
+```
+bq.job.query(prjId, 'select count(*) from publicdata:samples.wikipedia', function(e,r,d){
+  if(e) console.log(e);
+  if(d.jobIsComplete){
+      console.log(JSON.stringify(d));
+  } else {
+       bq.job.getQueryResults(prjId, d.jobReference.jobId, function(e,r,d){
+          console.log(JSON.stringify(d));
+       }
+  }
+});
+```
+
 ## Load data
 
 Before load data, you must create your dataset and table first. After that, you can use the following code to load data. (In this case test is the dataset id, testtb1 is the table name.)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bq.job.query(prjId, 'select count(*) from publicdata:samples.wikipedia', functio
 
 ## Get Query Results
 
-Retrieve results from previous query.  Larger queries will timeout and respond before ther esults are collected.  Use this to retrieve the results.  Below is an example.
+Retrieve results from a previously run query.  Larger queries will timeout and respond with no data before the results are collected.  Use this to retrieve the results.  Below is an example of querying and waiting for results.
 
 ```
 bq.job.query(prjId, 'select count(*) from publicdata:samples.wikipedia', function(e,r,d){

--- a/lib/bqapi.js
+++ b/lib/bqapi.js
@@ -39,7 +39,7 @@ exports.job  = {
         url: util.format(bqurl, project),
         method: 'POST',
     }, cb?cb:auth.commonCb);
-  }
+  },
   load: function(project, datasetId, tableId, data, cb){
     //see: https://developers.google.com/bigquery/docs/reference/v2/tabledata/insertAll
     var bqurl = 'https://www.googleapis.com/bigquery/v2/projects/%s/datasets/%s/tables/%s/insertAll';

--- a/lib/bqapi.js
+++ b/lib/bqapi.js
@@ -28,8 +28,7 @@ exports.job  = {
         url: util.format(bqurl, project),
         method: 'POST',
         json: {
-          query: bql,
-          timeout: timeout
+          query: bql
         }
     }, cb?cb:auth.commonCb);
   },

--- a/lib/bqapi.js
+++ b/lib/bqapi.js
@@ -32,6 +32,13 @@ exports.job  = {
         }
     }, cb?cb:auth.commonCb);
   },
+  getQueryResults: function(project, jobId, cb) {
+    var bqurl = 'https://www.googleapis.com/bigquery/v2/projects/%s/queries/%s';
+    request({
+        url: util.format(bqurl, project),
+        method: 'POST',
+    }, cb?cb:auth.commonCb);
+  }
   load: function(project, datasetId, tableId, data, cb){
     //see: https://developers.google.com/bigquery/docs/reference/v2/tabledata/insertAll
     var bqurl = 'https://www.googleapis.com/bigquery/v2/projects/%s/datasets/%s/tables/%s/insertAll';

--- a/lib/bqapi.js
+++ b/lib/bqapi.js
@@ -22,13 +22,14 @@ exports.init = function(opts) {
  */
 exports.job  = {
   token: '',
-  query: function(project, bql, cb) {
+  query: function(project, bql, opts, cb) {
     var bqurl = 'https://www.googleapis.com/bigquery/v2/projects/%s/queries';
     request({
         url: util.format(bqurl, project),
         method: 'POST',
         json: {
-          query: bql
+          query: bql,
+          timeout: timeout
         }
     }, cb?cb:auth.commonCb);
   },

--- a/lib/bqapi.js
+++ b/lib/bqapi.js
@@ -22,7 +22,7 @@ exports.init = function(opts) {
  */
 exports.job  = {
   token: '',
-  query: function(project, bql, opts, cb) {
+  query: function(project, bql, cb) {
     var bqurl = 'https://www.googleapis.com/bigquery/v2/projects/%s/queries';
     request({
         url: util.format(bqurl, project),


### PR DESCRIPTION
Add method to query for old jobs by id.  Allows you to handle queries that timeout but still generate results.
