### PR TITLE
Fixed getQueryResult method to GET, Enabled optional parameters

### DIFF
--- a/lib/bqapi.js
+++ b/lib/bqapi.js
@@ -33,6 +33,9 @@ exports.job  = {
     }, cb?cb:auth.commonCb);
   },
   getQueryResults: function(project, jobId, opts, cb) {
+    if(_.isFunction(opts)){
+      cb = opts;
+    }
     var bqurl = 'https://www.googleapis.com/bigquery/v2/projects/%s/queries/%s';
     request({
         url: util.format(bqurl, project, jobId),

--- a/lib/bqapi.js
+++ b/lib/bqapi.js
@@ -32,11 +32,12 @@ exports.job  = {
         }
     }, cb?cb:auth.commonCb);
   },
-  getQueryResults: function(project, jobId, cb) {
+  getQueryResults: function(project, jobId, opts, cb) {
     var bqurl = 'https://www.googleapis.com/bigquery/v2/projects/%s/queries/%s';
     request({
-        url: util.format(bqurl, project),
-        method: 'POST',
+        url: util.format(bqurl, project, jobId),
+        qs: opts,
+        method: 'GET',
     }, cb?cb:auth.commonCb);
   },
   load: function(project, datasetId, tableId, data, cb){


### PR DESCRIPTION
Hi,
I made a pull request to fix `getQueryResult` to work and enabled optional parameters to be passed.
Hope this gets merged soon!
